### PR TITLE
Fix date encoding

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -1571,6 +1571,7 @@ defmodule Tds.Types do
   end
 
   def encode_date(nil), do: nil
+  def encode_date(%Date{} = date), do: date |> Date.to_erl() |> encode_date()
 
   def encode_date(date) do
     days = :calendar.date_to_gregorian_days(date) - 366


### PR DESCRIPTION
`:calendar.date_to_gregorian_days` expects a tuple